### PR TITLE
force to derive debug

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("src/wrapper.h")
+        .derive_debug(true)
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
derive Debug on all structs, otherwise cargo clippy on xenevtchn crate won't build
![Capture d’écran de 2020-08-11 22-00-23](https://user-images.githubusercontent.com/964610/89943214-25d3f980-dc1e-11ea-836a-faa035ab80ee.png)
